### PR TITLE
multiple stability and cl param modifications

### DIFF
--- a/src/samplot.py
+++ b/src/samplot.py
@@ -1508,7 +1508,7 @@ if not options.json_only:
                     except ValueError:
                         ax.plot(r,[0,0],'-',color='black',lw=5)
                         if not options.hide_annotation_labels:
-                            ax.text(r[0],0 + 0.1,A[3],color='black')
+                            ax.text(r[0],0 + 0.1,A[3],color='black', fontsize=options.annotation_fontsize)
                 else:
                     ax.plot(r,[0,0],'-',color='black',lw=5)
 

--- a/src/samplot.py
+++ b/src/samplot.py
@@ -851,6 +851,9 @@ def plot_coverage(coverage,
         max_plot_depth = cover_y.max()
     ax2 = ax.twinx()
     ax2.set_xlim([0,1])
+    
+    if 0 == max_plot_depth:
+        max_plot_depth = 0.01
     ax2.set_ylim([0,max_plot_depth])
     ax2.fill_between(cover_x, \
                      cover_y, \
@@ -1271,12 +1274,14 @@ if not options.json_only:
     for i in range(len(bam_files)):
         ax =  matplotlib.pyplot.subplot(gs[ax_i])
         hps = sorted(all_coverages[i].keys(), reverse=True)
-        if 0 not in hps:
-            hps.append(0)
-        if 1 not in hps:
-            hps.append(1)
-        if 2 not in hps:
-            hps.append(2)
+        #if there are multiple haplotypes, must have 0,1,2
+        if len(hps) > 1:
+            if 0 not in hps:
+                hps.append(0)
+            if 1 not in hps:
+                hps.append(1)
+            if 2 not in hps:
+                hps.append(2)
         inner_axs = gridspec.GridSpecFromSubplotSpec(len(hps), 
                                                      1,
                                                      subplot_spec=gs[ax_i],

--- a/src/samplot.py
+++ b/src/samplot.py
@@ -394,6 +394,8 @@ def get_long_read_plan(read_name, long_reads, range_min, range_max):
         for alignment in long_read.alignments:
             alignments.append(alignment)
 
+    if len(alignments) <= 0:
+        return None
     alignments.sort(key=lambda x: x.query_position)
 
     gaps = []
@@ -781,6 +783,8 @@ def plot_long_reads(long_reads,
                                             long_reads,
                                             range_min,
                                             range_max)
+        if long_read_plan is None:
+            continue
         max_gap = long_read_plan[0]
         steps = long_read_plan[1]
         for step in steps:

--- a/src/samplot.py
+++ b/src/samplot.py
@@ -1258,13 +1258,14 @@ if not options.json_only:
         ax =  matplotlib.pyplot.subplot(gs[ax_i])
         hps = sorted(all_coverages[i].keys(), reverse=True)
         #if there are multiple haplotypes, must have 0,1,2
-        if len(hps) > 1:
+        if len(hps) > 1 or (len(hps) == 1 and hps[0] != 0):
             if 0 not in hps:
                 hps.append(0)
             if 1 not in hps:
                 hps.append(1)
             if 2 not in hps:
                 hps.append(2)
+        hps.sort(reverse=True)
         inner_axs = gridspec.GridSpecFromSubplotSpec(len(hps), 
                                                      1,
                                                      subplot_spec=gs[ax_i],

--- a/src/samplot.py
+++ b/src/samplot.py
@@ -1040,6 +1040,12 @@ parser.add_option("--legend_fontsize",
                   default=6,
                   help="Font size for legend labels (default 6)")
 
+parser.add_option("--annotation_fontsize",
+                  dest="annotation_fontsize",
+                  type=int,
+                  default=6,
+                  help="Font size for annotation labels (default 6)")
+
 parser.add_option("--common_insert_size",
                   dest="common_insert_size",
                   action="store_true",
@@ -1562,7 +1568,7 @@ if not options.json_only:
                    float(t_end - range_min)/float(range_max - range_min)]
                 ax.plot(r,[t_i,t_i],'-',color='cornflowerblue',lw=1)
 
-                ax.text(r[0],t_i + 0.02,gene,color='cornflowerblue')
+                ax.text(r[0],t_i + 0.02,gene,color='cornflowerblue', fontsize=options.annotation_fontsize)
 
             
                 if transcript in cdss:

--- a/src/samplot.py
+++ b/src/samplot.py
@@ -1273,7 +1273,10 @@ if not options.json_only:
         hps = sorted(all_coverages[i].keys(), reverse=True)
         if 0 not in hps:
             hps.append(0)
-
+        if 1 not in hps:
+            hps.append(1)
+        if 2 not in hps:
+            hps.append(2)
         inner_axs = gridspec.GridSpecFromSubplotSpec(len(hps), 
                                                      1,
                                                      subplot_spec=gs[ax_i],
@@ -1287,6 +1290,7 @@ if not options.json_only:
         curr_max_insert_size = None
 
         cover_axs = {}
+        curr_axs = ''
         for hp in hps:
             curr_ax = axs[hp]
 
@@ -1348,6 +1352,7 @@ if not options.json_only:
         #{{{ set axis parameters
         #set the axis title to be either one passed in or filename
         curr_ax = axs[hps[0]]
+
         if options.titles and \
                 len(options.titles.split(',')) == len(options.bams.split(',')):
             curr_ax.set_title(options.titles.split(',')[ax_i-1], \

--- a/src/samplot.py
+++ b/src/samplot.py
@@ -1035,6 +1035,13 @@ parser.add_option("--common_insert_size",
                   default=False,
                   help="Set common insert size for all plots")
 
+parser.add_option("--hide_annotation_labels",
+                  dest="hide_annotation_labels",
+                  action="store_true",
+                  default=False,
+                  help="Hide the label (fourth column text) from annotation files, useful for region with many annotations")
+
+
 (options, args) = parser.parse_args()
 if not options.output_file:
     parser.error('Output file not given')
@@ -1439,7 +1446,8 @@ if not options.json_only:
                         ax.plot(r,[0,0],'-',color=str(v),lw=5)
                     except ValueError:
                         ax.plot(r,[0,0],'-',color='black',lw=5)
-                        ax.text(r[0],0 + 0.1,A[3],color='black')
+                        if not options.hide_annotation_labels:
+                            ax.text(r[0],0 + 0.1,A[3],color='black')
                 else:
                     ax.plot(r,[0,0],'-',color='black',lw=5)
 


### PR DESCRIPTION
- added option to control annotation label font size
- added option to hide annotation labels (sometimes better to hide them when there are too many)
- modified legend to only show entry for reads types used within an image (so if no long reads, for example, not included in legend)
- modified y values for plots so that when there are no reads in a given plot, the x == y warning doesn't appear 
- fixed the case of missing a haplotype (if a haplotype was missing image would fail to render, now it succeeds and just plots that HP as empty)
- fixed the case of long reads having no data (before if no reads in a region, long read plotting would cause an unhandled error)

should fix #33, #34, #35, #37