### PR TITLE
example of logic fix for dups

### DIFF
--- a/src/samplot.py
+++ b/src/samplot.py
@@ -227,7 +227,6 @@ def add_split(read, splits, bam_file, linked_reads):
 
         splits[sr.HP][read.query_name]=[sr]
 
-        
         for sa in read.get_tag('SA').split(';'):
             if len(sa) == 0:
                 continue
@@ -729,13 +728,13 @@ def plot_split(split, y, ax, range_min, range_max):
     # Do not plot pairs that extend beyond the current range
     if range_min > start.end or range_max < end.start:
         return
-         
+
     p = [float(start.end - range_min)/float(range_max - range_min), \
          float(end.start - range_min)/float(range_max - range_min)]
 
     if p[0] < -5 or p[1] < -5 or p[0] > 5 or p[1] > 5:
         return
-       
+
     # For a given SV, the orientation of the pairs and split do not match
     # so we cannot use the colors dict here
     color = 'black'
@@ -752,7 +751,10 @@ def plot_split(split, y, ax, range_min, range_max):
     elif start.strand == False and \
          end.strand == False and \
          start.query_pos > end.query_pos: #DEL
-        color = 'black'
+        if start.start < end.start:
+          color = 'red'
+        else:
+          color = 'black'
     elif start.strand == True and \
          end.strand == True and \
          start.query_pos > end.query_pos: #DUP
@@ -760,7 +762,10 @@ def plot_split(split, y, ax, range_min, range_max):
     elif start.strand == False and \
          end.strand == False and \
          start.query_pos < end.query_pos: #DUP
-        color = 'red'
+        if start.start < end.start:
+          color = 'black' # DEL
+        else:
+          color = 'red' # DUP
 
     ax.plot(p,\
             [y,y],\


### PR DESCRIPTION
this is likely insufficient to fix all issues, but it's a major one.

as is, the statement for dups:
```
 start.strand == False and \
         end.strand == False and \
         start.query_pos < end.query_pos:
```

can certainly match an expected deletion signal, this fix adds to that condition, that for dups, the (reference) position of the end must be less than the (reference) position of the start.