### PR TITLE
Added larger matplotlib limit handler for chunksize under import, as …

### DIFF
--- a/samplot/samplot.py
+++ b/samplot/samplot.py
@@ -7,6 +7,7 @@ import re
 import sys
 
 import matplotlib
+matplotlib.rcParams['agg.path.chunksize'] = 10000
 matplotlib.use("Agg") #must be before imports of submodules in matplotlib
 import matplotlib.gridspec as gridspec
 import matplotlib.patches as mpatches


### PR DESCRIPTION
Added larger matplotlib limit handler for chunksize under import, as shown in https://github.com/matplotlib/matplotlib/issues/5907. This allows for larger sizes to be shown in the plot without the chunksize error given by MPL.