### PR TITLE
update to 1.0.13

### DIFF
--- a/samplot/__init__.py
+++ b/samplot/__init__.py
@@ -1,2 +1,2 @@
 #!/usr/bin/env python
-__version__ = "1.0.13"
+__version__ = "1.0.14"

--- a/samplot/__init__.py
+++ b/samplot/__init__.py
@@ -1,2 +1,2 @@
 #!/usr/bin/env python
-__version__ = "1.0.12"
+__version__ = "1.0.13"

--- a/samplot/__init__.py
+++ b/samplot/__init__.py
@@ -1,2 +1,2 @@
 #!/usr/bin/env python
-__version__ = "1.0.15"
+__version__ = "1.0.14"

--- a/samplot/__init__.py
+++ b/samplot/__init__.py
@@ -1,2 +1,2 @@
 #!/usr/bin/env python
-__version__ = "1.0.14"
+__version__ = "1.0.15"

--- a/samplot/samplot.py
+++ b/samplot/samplot.py
@@ -2351,7 +2351,7 @@ def estimate_fragment_len(bam, reference):
     frag_lens = []
 
     for i, read in enumerate(bam_file):
-        if 1 >= 10000:
+        if i >= 10000:
             break
         frag_lens.append(abs(read.tlen))
     if len(frag_lens) >= 5000:
@@ -3146,6 +3146,8 @@ def get_transcript_plan(ranges, transcript_file):
     for r in ranges:
         itr = get_tabix_iter(r.chrm, r.start, r.end, transcript_file)
         for row in itr:
+            print(row)
+            sys.exit()
             gene_annotation = row.rstrip().split()
 
             if gene_annotation[2] == "gene":

--- a/samplot/samplot.py
+++ b/samplot/samplot.py
@@ -113,9 +113,9 @@ class genome_interval:
     """ return -1 if before, 0 if in, 1 if after """
 
     def intersect(self, gi):
-        if gi.chrm.strip("chr") < self.chrm.strip("chr") or gi.end < self.start:
+        if gi.chrm.replace("chr", "") < self.chrm.replace("chr", "") or gi.end < self.start:
             return -1
-        elif gi.chrm.strip("chr") > self.chrm.strip("chr") or gi.start > self.end:
+        elif gi.chrm.replace("chr", "") > self.chrm.replace("chr", "") or gi.start > self.end:
             return 1
         else:
             return 0
@@ -128,7 +128,7 @@ def get_range_hit(ranges, chrm, point):
     for j in range(len(ranges)):
         r = ranges[j]
         if (
-            r.chrm.strip("chr") == chrm.strip("chr")
+            r.chrm.replace("chr", "") == chrm.replace("chr", "")
             and r.start <= point
             and r.end >= point
         ):
@@ -221,7 +221,7 @@ def add_coverage(bam_file, read, coverage, separate_mqual, ignore_hp):
     Quality is determined by separate_mqual, which is min quality
     """
 
-    chrm = bam_file.get_reference_name(read.reference_id).strip("chr")
+    chrm = bam_file.get_reference_name(read.reference_id).replace("chr", "")
 
     hp = 0
 
@@ -283,7 +283,6 @@ def plot_coverage(
     superimposed may cause unexpected behavior if low-quality depth is
     greater than high 
     """
-
     cover_x = []
     cover_y_lowqual = []
     cover_y_highqual = []
@@ -2273,7 +2272,7 @@ def add_plot(parent_parser):
         "-q",
         "--include_mqual",
         type=int,
-        help="Min mapping quality of reads to be included in plot",
+        help="Min mapping quality of reads to be included in plot (default 1)",
         default=1,
         required=False,
     )
@@ -3194,7 +3193,7 @@ def get_interval_range_plan_start_end(ranges, interval):
     if start_range_hit_i is None and end_range_hit_i is None:
         for i, range_item in enumerate(ranges):
             if (
-                (range_item.chrm.strip("chr") == interval.chrm.strip("chr"))
+                (range_item.chrm.replace("chr", "") == interval.chrm.replace("chr", ""))
                 and (interval.start <= range_item.start <= interval.end)
                 and (interval.start <= range_item.end <= interval.end)
             ):

--- a/samplot/samplot.py
+++ b/samplot/samplot.py
@@ -2877,11 +2877,10 @@ def plot_samples(
         # {{{ set axis parameters
         # set the axis title to be either one passed in or filename
         curr_ax = axs[hps[0]]
-
         if titles and len(titles) == len(bams):
-            curr_ax.set_title(titles[ax_i - 1], fontsize=8, loc="left")
+            curr_ax.set_title(titles[i], fontsize=8, loc="left")
         else:
-            curr_ax.set_title(os.path.basename(bams[ax_i - 1]), fontsize=8, loc="left")
+            curr_ax.set_title(os.path.basename(bams[i]), fontsize=8, loc="left")
 
         if len(axs) > 1:
             for j in axs:
@@ -3597,8 +3596,9 @@ def plot(parser):
     plt.tight_layout(pad=0.8, h_pad=0.1, w_pad=0.1)
     try:
         plt.savefig(output_file)
-    except:
+    except Exception as e:
         print(
             "Failed to save figure " + output_file
         )
+        print(e)
 # }}}

--- a/samplot/samplot.py
+++ b/samplot/samplot.py
@@ -3312,7 +3312,7 @@ def plot_transcript(
 
     # set axis parameters
     ax.set_xlim([0, 1])
-    ax.set_ylim([transcript_idx * -0.1, transcript_idx * 1.01])
+    ax.set_ylim([transcript_idx * -0.1, 0.01+(transcript_idx * 1.01)])
     ax.spines["top"].set_visible(False)
     ax.spines["bottom"].set_visible(False)
     ax.spines["left"].set_visible(False)

--- a/samplot/samplot.py
+++ b/samplot/samplot.py
@@ -2087,14 +2087,18 @@ def add_plot(parent_parser):
         if not os.path.isfile(bam):
             parser.error("alignment file {} does not exist or is not a valid file".format(bam))
         options = ["sam", "bam", "cram"]
-        idx_options = ["sai", "bai", "crai"]
+        idx_options = ["sai", "bai", "crai", "csi"]
         fields = os.path.splitext(bam)
         ext = fields[1][1:].lower()
         if ext not in options:
             parser.error("alignment file {} is not in SAM/BAM/CRAM format".format(bam))
         idx_type = idx_options[options.index(ext)]
+        #try the type-specific index name
         if not os.path.isfile(bam + "." + idx_type):
-            parser.error("alignment file {} has no index".format(bam))
+            idx_type = idx_options[3]
+            #try the csi index name
+            if not os.path.isfile(bam + "." + idx_type):
+                parser.error("alignment file {} has no index".format(bam))
         return bam
 
 

--- a/samplot/samplot.py
+++ b/samplot/samplot.py
@@ -3146,8 +3146,6 @@ def get_transcript_plan(ranges, transcript_file):
     for r in ranges:
         itr = get_tabix_iter(r.chrm, r.start, r.end, transcript_file)
         for row in itr:
-            print(row)
-            sys.exit()
             gene_annotation = row.rstrip().split()
 
             if gene_annotation[2] == "gene":

--- a/samplot/samplot_vcf.py
+++ b/samplot/samplot_vcf.py
@@ -634,7 +634,7 @@ def vcf(parser):
                 title_list.append(variant_sample)
 
         out_file.write(
-            "samplot plot {extra_args} -z {z} --minq 0 -n {titles} {cipos} {ciend} {svtype} -c {chrom} -s {start} -e {end} -o {fig_path} -d {downsample} -b {bams}\n".format(
+            "samplot plot {extra_args} -z {z} -n {titles} {cipos} {ciend} {svtype} -c {chrom} -s {start} -e {end} -o {fig_path} -d {downsample} -b {bams}\n".format(
                 extra_args=" ".join(pass_through_args),
                 bams=" ".join(bams),
                 titles=" ".join(title_list),

--- a/test/func/samplot_test.sh
+++ b/test/func/samplot_test.sh
@@ -175,7 +175,7 @@ run from_vcf_auto \
         $data_path"HG003_Illumina.bam" \
         $data_path"HG004_Illumina.bam" 
 if [ $from_vcf_auto ]; then
-    assert_in_stderr "Window size is under 1.5x the estimated fragment length and will be resized to 843. Rerun with -w 604 to override"
+    assert_in_stderr "Window size is under 1.5x the estimated fragment length and will be resized to 847. Rerun with -w 604 to override"
     assert_exit_code 0
     assert_equal $test_dir/index.html $( ls $test_dir/index.html )
     assert_equal $test_dir/DEL_1_24804397_24807302.png $( ls $test_dir/DEL_1_24804397_24807302.png )

--- a/test/func/samplot_test.sh
+++ b/test/func/samplot_test.sh
@@ -296,7 +296,6 @@ run longread_del_zoom_big_zoom \
 if [ $longread_del_zoom_big_zoom ]; then
     assert_exit_code 0
     assert_equal $out_file_name $( ls $out_file_name )
-    assert_in_stderr "Ignoring zoom command."
     assert_in_stderr "Insufficient reads for fragment length estimate."
     assert_no_stdout
 fi

--- a/test/unit/samplot_test.py
+++ b/test/unit/samplot_test.py
@@ -38,7 +38,7 @@ class Test_set_plot_dimensions(unittest.TestCase):
         annotation_files = None
         transcript_file = None
 
-        zoom = None
+        zoom = 500000
 
         window = None
 
@@ -151,7 +151,8 @@ class Test_set_plot_dimensions(unittest.TestCase):
                                                options.long_read,
                                                options.same_yaxis_scales,
                                                options.max_depth,
-                                               options.z)
+                                               options.z,
+                                               options.ignore_hp)
         '''
 
         plot_height = None
@@ -160,7 +161,7 @@ class Test_set_plot_dimensions(unittest.TestCase):
         annotation_files = None
         transcript_file = None
 
-        zoom = None
+        zoom = 500000
 
         window = None
 

--- a/test/unit/samplot_test.py
+++ b/test/unit/samplot_test.py
@@ -146,7 +146,8 @@ class Test_set_plot_dimensions(unittest.TestCase):
         read_data,max_coverage = get_read_data(ranges,
                                                options.bams,
                                                options.reference,
-                                               options.min_mqual,
+                                               options.separate_mqual,
+                                               options.include_mqual,
                                                options.coverage_only,
                                                options.long_read,
                                                options.same_yaxis_scales,
@@ -181,24 +182,28 @@ class Test_set_plot_dimensions(unittest.TestCase):
                                         zoom)
 
         reference = None
-        min_mqual = None
+        separate_mqual = 0
+        include_mqual = 1
         coverage_only = None
         long_read = 1000
-        long_even_size = 100
+        long_event_size = 100
         same_yaxis_scales = None
         max_depth = 100
         z = 4
+        ignore_hp = False
 
         read_data,max_coverage = samplot.get_read_data(r_ranges,
                                                        bams,
                                                        reference,
-                                                       min_mqual,
+                                                       separate_mqual,
+                                                       include_mqual,
                                                        coverage_only,
                                                        long_read,
-                                                       long_even_size,
+                                                       long_event_size,
                                                        same_yaxis_scales,
                                                        max_depth,
-                                                       z)
+                                                       z,
+                                                       ignore_hp)
     #}}}
 #}}}
 


### PR DESCRIPTION
* Added filetype/index and file existence checks for SAM/BAM/CRAM/BED/GFF/GFF3 inputs
* added option to ignore HP tag in plot
* changed default `-d` to not plot normal pairs
* padded image to remove padding warning
* fixed a bug in insert size calculation (big speedup)
* added autogeneration for output filename (can still be user-specified)
* added option to change DPI (pixel count) in images
* set default to zoom for regions greater than 500KB
* removed annoying warning message for when zoom is ignored (added to argparse help instead)
* added option for output directory argument so that when plot name is autogenerated it doesn’t have to go in the working dir
* added options to name annotation_files and transcript_file
* changed the names of mapq options for clarity
* updated tests for new changes
