### PR TITLE
Samplot minor fixes, mostly in VCF

### DIFF
--- a/.circleci/setup.sh
+++ b/.circleci/setup.sh
@@ -37,6 +37,7 @@ if [[ ! -d $WORKSPACE/anaconda ]]; then
     sudo chown -R $USER $WORKSPACE/anaconda/
 
     mkdir -p $WORKSPACE/anaconda/conda-bld/$tag-64
+    conda create -n test python="$pythonversion.7"
 
     # step 2: setup channels
     conda config --system --add channels defaults

--- a/.circleci/setup.sh
+++ b/.circleci/setup.sh
@@ -38,6 +38,7 @@ if [[ ! -d $WORKSPACE/anaconda ]]; then
 
     mkdir -p $WORKSPACE/anaconda/conda-bld/$tag-64
     conda create -n test python="$pythonversion.7" -y
+    conda init bash
     conda activate test
 
     # step 2: setup channels

--- a/.circleci/setup.sh
+++ b/.circleci/setup.sh
@@ -37,7 +37,7 @@ if [[ ! -d $WORKSPACE/anaconda ]]; then
     sudo chown -R $USER $WORKSPACE/anaconda/
 
     mkdir -p $WORKSPACE/anaconda/conda-bld/$tag-64
-    conda create -n test python="$pythonversion.7"
+    conda create -n test python="$pythonversion.7" -y
 
     # step 2: setup channels
     conda config --system --add channels defaults

--- a/.circleci/setup.sh
+++ b/.circleci/setup.sh
@@ -38,6 +38,7 @@ if [[ ! -d $WORKSPACE/anaconda ]]; then
 
     mkdir -p $WORKSPACE/anaconda/conda-bld/$tag-64
     conda create -n test python="$pythonversion.7" -y
+    conda activate test
 
     # step 2: setup channels
     conda config --system --add channels defaults

--- a/.circleci/setup.sh
+++ b/.circleci/setup.sh
@@ -37,11 +37,14 @@ if [[ ! -d $WORKSPACE/anaconda ]]; then
     sudo chown -R $USER $WORKSPACE/anaconda/
 
     mkdir -p $WORKSPACE/anaconda/conda-bld/$tag-64
-    conda create -n test python="$pythonversion.7" -y
-    conda init bash
-    conda activate test
 
-    # step 2: setup channels
+    #step 2: downgrade python3.8 to 3.7
+    if (( $pythonversion == 3 ))
+    then
+        conda install -y python=3.7
+    fi
+
+    # step 3: setup channels
     conda config --system --add channels defaults
     conda config --system --add channels r
     conda config --system --add channels bioconda

--- a/samplot/__init__.py
+++ b/samplot/__init__.py
@@ -1,2 +1,2 @@
 #!/usr/bin/env python
-__version__ = "1.0.15"
+__version__ = "1.0.16"

--- a/samplot/__init__.py
+++ b/samplot/__init__.py
@@ -1,2 +1,2 @@
 #!/usr/bin/env python
-__version__ = "1.0.16"
+__version__ = "1.0.17"

--- a/samplot/samplot.py
+++ b/samplot/samplot.py
@@ -15,6 +15,8 @@ import matplotlib.pyplot as plt
 import matplotlib.ticker as ticker
 import numpy as np
 import pysam
+import warnings
+warnings.filterwarnings('ignore', 'FixedFormatter should only be used together with FixedLocator')
 from matplotlib.offsetbox import AnchoredText
 
 
@@ -357,6 +359,7 @@ def plot_coverage(
     tick_count = max(int(max_plot_depth / tick_count), 1)
 
     # set axis parameters
+    #ax2.yaxis.set_major_locator(ticker.FixedLocator(tick_count))
     ax2.yaxis.set_major_locator(ticker.MultipleLocator(tick_count))
     ax2.tick_params(axis="y", colors="grey", labelsize=yaxis_label_fontsize)
     ax2.spines["top"].set_visible(False)
@@ -2913,6 +2916,7 @@ def plot_samples(
             curr_ax.tick_params(axis="y", labelsize=yaxis_label_fontsize)
             # if there's one hp, 6 ticks fit. Otherwise, do 3
             tick_count = 6 if len(hps) == 1 else 3
+            #curr_ax.yaxis.set_major_locator(ticker.FixedLocator(tick_count))
             curr_ax.yaxis.set_major_locator(ticker.LinearLocator(tick_count))
             curr_ax.tick_params(axis="both", length=0)
             curr_ax.set_xticklabels([])
@@ -2950,7 +2954,7 @@ def plot_samples(
             else:
                 sys.stderr.write("Ranges greater than 2 are not supported\n")
                 sys.exit(1)
-
+            
             curr_ax.set_xticklabels(labels, fontsize=xaxis_label_fontsize)
             chrms = [x.chrm for x in ranges]
             curr_ax.set_xlabel("Chromosomal position on " + "/".join(chrms), fontsize=8)

--- a/samplot/samplot.py
+++ b/samplot/samplot.py
@@ -2136,7 +2136,7 @@ def add_plot(parent_parser):
         "-s",
         "--start",
         type=int,
-        help="Start position of region/variant",
+        help="Start position of region/variant (add multiple for translocation/BND events)",
         action="append",
         required=True,
     )
@@ -2145,7 +2145,7 @@ def add_plot(parent_parser):
         "-e",
         "--end",
         type=int,
-        help="End position of region/variant",
+        help="End position of region/variant (add multiple for translocation/BND events)",
         action="append",
         required=True,
     )
@@ -2153,7 +2153,7 @@ def add_plot(parent_parser):
     parser.add_argument(
         "-c",
         "--chrom", type=str,
-        help="Chromosome",
+        help="Chromosome (add multiple for translocation/BND events)",
         action="append",
         required=True
     )

--- a/samplot/samplot_vcf.py
+++ b/samplot/samplot_vcf.py
@@ -441,7 +441,10 @@ def vcf(parser):
     out_file = open(args.command_file, "w")
 
     for var_count,variant in enumerate(vcf):
-        translocation_chrom = variant.info.get("CHR2")
+        try:
+            translocation_chrom = variant.info.get("CHR2")
+        except:
+            translocation_chrom = None
         svtype = variant.info.get("SVTYPE", "SV")
         if args.important_regions:
             if not var_in_important_regions(

--- a/samplot/samplot_vcf.py
+++ b/samplot/samplot_vcf.py
@@ -440,30 +440,51 @@ def vcf(parser):
 
     out_file = open(args.command_file, "w")
 
-    for variant in vcf:
+    for var_count,variant in enumerate(vcf):
         svtype = variant.info.get("SVTYPE", "SV")
         if args.important_regions:
             if not var_in_important_regions(
                 important_regions, variant.chrom, variant.start, variant.stop
             ):
+                if args.debug:
+                    print("Skipping {} at {}:{}-{}, outside important_regions coordinates".format(
+                        svtype, variant.chrom, variant.start, variant.stop),file=sys.stderr)
                 continue
 
         if svtype in ("INS"):
+            if args.debug:
+                print("Skipping {} at {}:{}-{}, INS type not supported".format(
+                    svtype, variant.chrom, variant.start, variant.stop),file=sys.stderr)
             continue
         if variant.stop - variant.start > args.max_mb * 1000000:
+            if args.debug:
+                print("Skipping {} at {}:{}-{}, variant length greater than max_mb".format(
+                    svtype, variant.chrom, variant.start, variant.stop),file=sys.stderr)
             continue
         if variant.stop - variant.start < args.min_bp:
+            if args.debug:
+                print("Skipping {} at {}:{}-{}, variant length shorter than min_bp".format(
+                    svtype, variant.chrom, variant.start, variant.stop),file=sys.stderr)
             continue
 
         gts = [s.get("GT", (None, None)) for s in variant.samples.values()]
 
         if sum(None in g for g in gts) >= args.min_call_rate * len(vcf_samples):
+            if args.debug:
+                print("Skipping {} at {}:{}-{}, call rate of variant below min_call_rate".format(
+                    svtype, variant.chrom, variant.start, variant.stop),file=sys.stderr)
             continue
         if args.max_hets:
             # requisite hets/hom-alts
             if sum(sum(x) >= 1 for x in gts if not None in x) > args.max_hets:
+                if args.debug:
+                    print("Skipping {} at {}:{}-{}, more than max_hets heterozygotes".format(
+                        svtype, variant.chrom, variant.start, variant.stop),file=sys.stderr)
                 continue
         if not any(sum(x) > 0 for x in gts if not None in x):
+            if args.debug:
+                print("Skipping {} at {}:{}-{}, no samples have non-ref genotypes".format(
+                    svtype, variant.chrom, variant.start, variant.stop),file=sys.stderr)
             continue
 
         test_idxs = [i for i, gt in enumerate(gts) if not None in gt and sum(gt) > 0]
@@ -493,7 +514,10 @@ def vcf(parser):
         for i in idxs:
             if vcf_samples[i] in names_to_bams:
                 variant_samples.append(vcf_samples[i])
-        if len(variant_samples) <= 0:
+        if len(variant_samples) == 0:
+            if args.debug:
+                print("Skipping {} at {}:{}-{}, no samples with matched alignment files have variant".format(
+                    svtype, variant.chrom, variant.start, variant.stop),file=sys.stderr)
             continue
 
         bams = [names_to_bams[s] for s in variant_samples]
@@ -510,6 +534,9 @@ def vcf(parser):
                     is_dn.append(sample.id)
 
         if len(is_dn) <= 0 and args.dn_only:
+            if args.debug:
+                print("Skipping {} at {}:{}-{}, dn_only selected and no de novos found".format(
+                    svtype, variant.chrom, variant.start, variant.stop),file=sys.stderr)
             continue
 
         # save these for the html.
@@ -649,6 +676,8 @@ def vcf(parser):
                 downsample=args.downsample,
             )
         )
+    if args.debug:
+        print("VCF entry count:",var_count+1 ,file=sys.stderr)
 
     if args.command_file:
         out_file.close()
@@ -802,7 +831,12 @@ def add_vcf(parent_parser):
         default=False,
         action="store_true",
     )
-
+    parser.add_argument(
+        "--debug",
+        help="prints out the reason each skipped variant entry is skipped",
+        default=False,
+        action="store_true",
+    )
     parser.set_defaults(func=vcf)
 
 


### PR DESCRIPTION
- Added CL option to debug in samplot (easier to figure out why variants don't get plotted)
- Implemented split-pane window for VCF plotting of translocations
- Required python to use v3.7 as 3.8 breaks dependencies
- Downsampled coverage plot a bit for large regions to speed up plotting