### PR TITLE
allow alignment file indices with name pattern {filename}.{bai/crai}

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,8 +117,7 @@ conda install -c bioconda samplot
 ## Examples: 
 
 Samplot requires either BAM files or CRAM files as primary input. If you use
-CRAM, you'll also need a reference genome like one used the the [1000 Genomes
-Project](ftp://ftp-trace.ncbi.nih.gov/1000genomes/ftp/technical/reference/human_g1k_v37.fasta.gz).
+CRAM, you'll also need a reference genome. You can easily acquire a reference genome file with [GGD](https://github.com/gogetdata/ggd-cli), which is also available from conda.
 
 ### Basic use case
 Using data from NA12878, NA12889, and NA12890 in the 

--- a/samplot/__init__.py
+++ b/samplot/__init__.py
@@ -1,2 +1,2 @@
 #!/usr/bin/env python
-__version__ = "1.0.17"
+__version__ = "1.0.18"

--- a/samplot/samplot.py
+++ b/samplot/samplot.py
@@ -2106,7 +2106,9 @@ def add_plot(parent_parser):
             parser.error("alignment file {} is not in SAM/BAM/CRAM format".format(bam))
         idx_type = idx_options[options.index(ext)]
         #try the type-specific index name
-        if not os.path.isfile(bam + "." + idx_type):
+        picard_bam = os.path.splitext(bam)[0]
+        if (not os.path.isfile(bam + "." + idx_type) and 
+                not os.path.isfile(picard_bam + "." + idx_type)):
             idx_type = idx_options[3]
             #try the csi index name
             if not os.path.isfile(bam + "." + idx_type):


### PR DESCRIPTION
Fixed #110 to allow picardtools-style index names