### PR TITLE
Add option '--jitter' to avoid overlaps

### DIFF
--- a/samplot/samplot.py
+++ b/samplot/samplot.py
@@ -1901,6 +1901,7 @@ def plot_linked_reads(
     curr_min_insert_size,
     curr_max_insert_size,
     marker_size,
+    jitter_bounds,
 ):
     """Plots all LinkedReads for the region
     """
@@ -1911,6 +1912,8 @@ def plot_linked_reads(
             continue
 
         insert_size, steps = plan
+
+        insert_size = jitter(insert_size, bounds=jitter_bounds)
 
         if not curr_min_insert_size or curr_min_insert_size > insert_size:
             curr_min_insert_size = insert_size
@@ -1936,11 +1939,11 @@ def plot_linked_reads(
 
         for pair_step in steps[0].info["PAIR_STEPS"]:
             pair_step.info["INSERTSIZE"] = insert_size
-            plot_pair_plan(ranges, pair_step, ax, marker_size)
+            plot_pair_plan(ranges, pair_step, ax, marker_size, jitter_bounds)
 
         for split_step in steps[0].info["SPLIT_STEPS"]:
             split_step.info["INSERTSIZE"] = insert_size
-            plot_split_plan(ranges, split_step, ax, marker_size)
+            plot_split_plan(ranges, split_step, ax, marker_size, jitter_bounds)
 
     return [curr_min_insert_size, curr_max_insert_size]
 
@@ -2935,6 +2938,7 @@ def plot_samples(
                     curr_min_insert_size,
                     curr_max_insert_size,
                     marker_size,
+                    jitter_bounds
                 )
             elif len(curr_long_reads) > 0:
                 curr_min_insert_size, curr_max_insert_size = plot_long_reads(


### PR DESCRIPTION
I run into the issue where a lot of evidence for a variant is hidden because of overlapping lines for disc read , split reads etc, similar to #98.

This PR implements a very simpler jitter function to make it easier to check how much support there is. This offsets the inserts size of each line (y-dim) within the defined bounds (currently 8% of length) by a random value. 

I used the example from the [README](https://github.com/ryanlayer/samplot#examples) to test this. 

    samplot plot     -n NA12878 NA12889 NA12890     -b test/data/NA12878_restricted.bam       test/data/NA12889_restricted.bam       test/data/NA12890_restricted.bam     -o 4_115928726_115931880_orig.png     -c chr4     -s 115928726     -e 115931880     -t DEL

**Before**
![image](https://user-images.githubusercontent.com/27061883/154039290-1936d615-5c1b-4d52-9440-4fc408a6dbe7.png)

**After**
![image](https://user-images.githubusercontent.com/27061883/154039316-d97cb4ce-6b51-4c50-a13b-12ba12d98fcc.png)

I also added a new hidden argument that sets a random seed to make output deterministic. Note that this also affects the read downsampling. 
