### PR TITLE
Fix incomplete testing

### DIFF
--- a/test/func/samplot_vcf_test.sh
+++ b/test/func/samplot_vcf_test.sh
@@ -160,7 +160,7 @@ run denovo_only_noped \
         -b $data_path"HG002_Illumina.bam" \
         $data_path"HG003_Illumina.bam" \
         $data_path"HG004_Illumina.bam" \
-        --dn_only\
+        --dn_only
 if [ $denovo_only_noped ]; then
     assert_in_stderr "Missing --ped, required when using --dn_only"
 fi


### PR DESCRIPTION
Tests `denovo_only_noped` and `denovo_only` did not run due to a syntax error:

    test/func/samplot_vcf_test.sh: line 227: syntax error near unexpected token `then'
    test/func/samplot_vcf_test.sh: line 227: `if [ $denovo_only_noped ]; then'