### PR TITLE
Multithread plot generation from VCF

### DIFF
--- a/samplot/samplot.py
+++ b/samplot/samplot.py
@@ -3672,4 +3672,6 @@ def plot(parser, options, extra_args=None):
             "Failed to save figure " + output_file
         )
         print(e)
+
+    plt.close(fig)
 # }}}

--- a/samplot/samplot_vcf.py
+++ b/samplot/samplot_vcf.py
@@ -1183,8 +1183,13 @@ def vcf(parser, args, pass_through_args):
         with open(args.command_file, "w") as outfile:
             outfile.writelines(commands)
     else:
-        for command in commands:
-            run_plot_command(command)
+        if args.threads == 1:
+            for command in commands:
+                run_plot_command(command)
+        else:
+            from multiprocessing import Pool
+            with Pool(processes=args.threads) as pool:
+                pool.map(run_plot_command, commands)
 
 
 def add_vcf(parent_parser):
@@ -1325,6 +1330,12 @@ def add_vcf(parent_parser):
         + "limited by any filtering arguments set",
         default=False,
         action="store_true",
+    )
+    parser.add_argument(
+        "-t", "--threads",
+        type=int,
+        default=1,
+        help="Number of threads to use to generate plots. Default: %(default)s",
     )
     parser.add_argument(
         "--debug",

--- a/test/func/samplot_vcf_test.sh
+++ b/test/func/samplot_vcf_test.sh
@@ -118,6 +118,35 @@ rm -rf $test_dir
 
 vcf_file=$data_path"test.vcf"
 cmd_file=$func_path"test.cmd"
+test_dir=$func_path"test_vcf_auto_multithread_dir"
+rm -rf $test_dir
+run from_vcf_auto_multithread \
+    samplot vcf \
+        -d $test_dir \
+        --vcf $vcf_file \
+        --sample_ids HG002 HG003 HG004 \
+        -b $data_path"HG002_Illumina.bam" \
+        $data_path"HG003_Illumina.bam" \
+        $data_path"HG004_Illumina.bam" \
+        -t 2
+if [ $from_vcf_auto_multithread ]; then
+    assert_in_stderr "Window size is under 1.5x the estimated fragment length and will be resized to 847. Rerun with -w 604 to override"
+    assert_exit_code 0
+    assert_equal $test_dir/index.html $( ls $test_dir/index.html )
+    assert_equal $test_dir/DEL_1_24804397_24807302.png $( ls $test_dir/DEL_1_24804397_24807302.png )
+    assert_equal $test_dir/DUP_4_99813786_99817098.png $( ls $test_dir/DUP_4_99813786_99817098.png )
+    assert_equal $test_dir/DUP_11_67974431_67975639.png $( ls $test_dir/DUP_11_67974431_67975639.png )
+    assert_equal $test_dir/INV_12_12544867_12546613.png $( ls $test_dir/INV_12_12544867_12546613.png )
+    assert_equal $test_dir/DEL_19_12694866_12698924.png $( ls $test_dir/DEL_19_12694866_12698924.png )
+    assert_equal $test_dir/TRA_1_24804398_43059290.png $( ls $test_dir/TRA_1_24804398_43059290.png )
+    assert_equal $test_dir/TRA_1_24804399_99813787.png $( ls $test_dir/TRA_1_24804399_99813787.png )
+fi
+rm -f $cmd_file
+rm -rf $test_dir
+
+
+vcf_file=$data_path"test.vcf"
+cmd_file=$func_path"test.cmd"
 test_dir=$func_path"test_plotall_dir"
 rm -f $cmd_file
 rm -rf $test_dir
@@ -146,6 +175,40 @@ if [ $plot_all ]; then
 fi
 rm -f $cmd_file
 rm -rf $test_dir
+
+
+vcf_file=$data_path"test.vcf"
+cmd_file=$func_path"test.cmd"
+test_dir=$func_path"test_plotall_multithread_dir"
+rm -f $cmd_file
+rm -rf $test_dir
+run plot_all_multithread \
+    samplot vcf \
+        -d $test_dir \
+        --vcf $vcf_file \
+        --sample_ids HG002 HG003 HG004 \
+        -b $data_path"HG002_Illumina.bam" \
+        $data_path"HG003_Illumina.bam" \
+        $data_path"HG004_Illumina.bam" \
+        --plot_all \
+        -t 2
+if [ $plot_all_multithread ]; then
+    assert_in_stderr "Window size is under 1.5x the estimated fragment length and will be resized to 847. Rerun with -w 604 to override"
+    assert_exit_code 0
+    assert_equal "$test_dir/index.html" $( ls $test_dir/index.html )
+    assert_equal "$test_dir/DEL_19_12694866_12698924.png" $( ls "$test_dir/DEL_19_12694866_12698924.png" )
+    assert_equal "$test_dir/DUP_4_99813786_99817098.png" $( ls "$test_dir/DUP_4_99813786_99817098.png" )
+    assert_equal "$test_dir/DUP_4_99813786_99817098.png" $( ls "$test_dir/DUP_4_99813786_99817098.png" )
+    assert_equal "$test_dir/TRA_1_24804398_43059290.png" $( ls $test_dir/TRA_1_24804398_43059290.png )
+    assert_equal "$test_dir/TRA_1_24804399_99813787.png" $( ls $test_dir/TRA_1_24804399_99813787.png )
+    assert_equal "$test_dir/DEL_1_24804397_24807302.png" $( ls "$test_dir/DEL_1_24804397_24807302.png" )
+    assert_equal "$test_dir/DUP_11_67974431_67975639.png" $( ls "$test_dir/DUP_11_67974431_67975639.png" )
+    assert_equal "$test_dir/INV_12_12544867_12546613.png" $( ls "$test_dir/INV_12_12544867_12546613.png" )
+
+fi
+rm -f $cmd_file
+rm -rf $test_dir
+
 
 vcf_file=$data_path"test.vcf"
 cmd_file="test.cmd"


### PR DESCRIPTION
This PR adds the ability to speed up plot generation from VCFs using multithreading.

I tested on the datasets in `test` using 1 to 4 threads. Speedup look quite good, for example for 4 threads there was ~2.5x speedup compare to using a single thread. See benchmarks below.

**Benchmarks**
```
Benchmark #1: samplot vcf -d tmp --vcf test/data/test.vcf --sample_ids HG002 HG003 HG004 -b test/data/HG002_Illumina.bam test/data/HG003_Illumina.bam test/data/HG004_Illumina.bam -t 1
  Time (mean ± σ):     21.877 s ±  0.110 s    [User: 29.183 s, System: 1.375 s]
  Range (min … max):   21.767 s … 21.987 s    3 runs
 
Benchmark #2: samplot vcf -d tmp --vcf test/data/test.vcf --sample_ids HG002 HG003 HG004 -b test/data/HG002_Illumina.bam test/data/HG003_Illumina.bam test/data/HG004_Illumina.bam -t 2
  Time (mean ± σ):     12.573 s ±  0.250 s    [User: 32.452 s, System: 1.891 s]
  Range (min … max):   12.417 s … 12.861 s    3 runs
  
Benchmark #3: samplot vcf -d tmp --vcf test/data/test.vcf --sample_ids HG002 HG003 HG004 -b test/data/HG002_Illumina.bam test/data/HG003_Illumina.bam test/data/HG004_Illumina.bam -t 3
  Time (mean ± σ):     10.105 s ±  0.199 s    [User: 34.133 s, System: 3.174 s]
  Range (min … max):    9.960 s … 10.332 s    3 runs
 
Benchmark #4: samplot vcf -d tmp --vcf test/data/test.vcf --sample_ids HG002 HG003 HG004 -b test/data/HG002_Illumina.bam test/data/HG003_Illumina.bam test/data/HG004_Illumina.bam -t 4
  Time (mean ± σ):      8.243 s ±  0.086 s    [User: 36.191 s, System: 3.136 s]
  Range (min … max):    8.186 s …  8.341 s    3 runs
```