### PR TITLE
Handle GFF with missing "Name" gene attribute

### DIFF
--- a/samplot/samplot.py
+++ b/samplot/samplot.py
@@ -3176,8 +3176,6 @@ def get_interval_range_plan_start_end(ranges, interval):
 
 # {{{def get_transcript_plan(ranges, transcript_file):
 def get_transcript_plan(ranges, transcript_file):
-    transcript_plan = []
-
     genes = {}
     transcripts = {}
     cdss = {}
@@ -3195,6 +3193,9 @@ def get_transcript_plan(ranges, transcript_file):
                 )
 
                 info["strand"] = gene_annotation[6] == "+"
+
+                if "Name" not in info:
+                    continue
 
                 genes[info["Name"]] = [
                     genome_interval(


### PR DESCRIPTION
I downloaded the latest GFF3 for GRCh38 (`Homo_sapiens.GRCh38.106.sort.gff3.gz`) from ensmbl according to the [instructions](https://github.com/ryanlayer/samplot#gene-and-other-genomic-feature-annotations). When I used this I run into this error: 

```
  File "/home/phojer/.conda/envs/samplot/bin/samplot", line 10, in <module>
    sys.exit(main())
  File "/home/phojer/.conda/envs/samplot/lib/python3.9/site-packages/samplot/__main__.py", line 31, in main
    args.func(parser, args, extra_args)
  File "/home/phojer/.conda/envs/samplot/lib/python3.9/site-packages/samplot/samplot.py", line 3655, in plot
    plot_transcript(
  File "/home/phojer/.conda/envs/samplot/lib/python3.9/site-packages/samplot/samplot.py", line 3419, in plot_transcript
    transcript_plan = get_transcript_plan(ranges, transcript_file)
  File "/home/phojer/.conda/envs/samplot/lib/python3.9/site-packages/samplot/samplot.py", line 3331, in get_transcript_plan
    genes[info["Name"]] = [
KeyError: 'Name'
```

Apparently there are entries missing the "Name" attribute such as these below. 

```
$ zless  Homo_sapiens.GRCh38.106.sort.gff3.gz | awk ' $3 == "gene" {print}' | grep -v "Name=" | head
1	havana	gene	2566410	2569888	.	+	.	ID=gene:ENSG00000225931;biotype=TEC;description=novel transcript;gene_id=ENSG00000225931;logic_name=havana_homo_sapiens;version=3
1	havana	gene	3205988	3208664	.	+	.	ID=gene:ENSG00000279839;biotype=TEC;description=TEC;gene_id=ENSG00000279839;logic_name=havana_homo_sapiens;version=1
1	havana	gene	6159430	6197757	.	-	.	ID=gene:ENSG00000285629;biotype=protein_coding;description=novel transcript;gene_id=ENSG00000285629;logic_name=havana_homo_sapiens;version=1
1	ensembl_havana	gene	9826289	9828271	.	-	.	ID=gene:ENSG00000280113;biotype=TEC;description=TEC;gene_id=ENSG00000280113;logic_name=ensembl_havana_gene_homo_sapiens;version=2
1	havana	gene	17005068	17011757	.	-	.	ID=gene:ENSG00000288636;biotype=protein_coding;description=novel  protein;gene_id=ENSG00000288636;logic_name=havana_homo_sapiens;version=1
1	havana	gene	18109389	18115861	.	+	.	ID=gene:ENSG00000280222;biotype=TEC;description=TEC;gene_id=ENSG00000280222;logic_name=havana_homo_sapiens;version=1
1	havana	gene	21547404	21554002	.	+	.	ID=gene:ENSG00000289715;biotype=protein_coding;description=novel protein;gene_id=ENSG00000289715;logic_name=havana_homo_sapiens;version=1
1	havana	gene	22025142	22092943	.	+	.	ID=gene:ENSG00000289694;biotype=protein_coding;description=novel protein;gene_id=ENSG00000289694;logic_name=havana_homo_sapiens;version=1
1	havana	gene	22364630	22366482	.	-	.	ID=gene:ENSG00000279625;biotype=TEC;description=TEC;gene_id=ENSG00000279625;logic_name=havana_homo_sapiens;version=1
1	havana	gene	22636506	22644067	.	+	.	ID=gene:ENSG00000289692;biotype=protein_coding;description=novel protein;gene_id=ENSG00000289692;logic_name=havana_homo_sapiens;version=1
```


While you could filter these out this PR skips these entries for convenience.
