### PR TITLE
Transcript plotting update

### DIFF
--- a/samplot/samplot.py
+++ b/samplot/samplot.py
@@ -3312,13 +3312,6 @@ def plot_transcript(
             p, [transcript_idx, transcript_idx], "-", color="cornflowerblue", lw=0.5
         )
 
-        ax.text(
-            p[0],
-            transcript_idx + 0.1,
-            step.info["Name"],
-            color="blue",
-            fontsize=annotation_fontsize,
-        )
         # Print arrows throughout gene to show direction.
         nr_arrows = 2 + int((p[1]-p[0])/0.02)
         arrow_locs = np.linspace(p[0], p[1], nr_arrows)
@@ -3348,7 +3341,7 @@ def plot_transcript(
 
         if step.info["Exons"]:
             for exon in step.info["Exons"]:
-                p = [
+                p_exon = [
                     map_genome_point_to_range_points(
                         ranges, exon.start_pos.chrm, exon.start_pos.start
                     ),
@@ -3356,16 +3349,25 @@ def plot_transcript(
                         ranges, exon.end_pos.chrm, exon.end_pos.end
                     ),
                 ]
-                if not points_in_window(p):
+                if not points_in_window(p_exon):
                     continue
 
                 ax.plot(
-                    p,
+                    p_exon,
                     [transcript_idx, transcript_idx],
                     "-",
                     color="cornflowerblue",
                     lw=4,
                 )
+
+        ax.text(
+            sum(p)/2,
+            transcript_idx + 0.1,
+            step.info["Name"],
+            color="blue",
+            fontsize=annotation_fontsize,
+            ha="center"
+        )
 
         transcript_idx += 1
         transcript_idx_max = max(transcript_idx, transcript_idx_max)

--- a/samplot/samplot.py
+++ b/samplot/samplot.py
@@ -3281,7 +3281,8 @@ def plot_transcript(
     if not transcript_filename:
         transcript_filename = os.path.basename(transcript_file)
     transcript_idx = 0
-    arrow_loc = 0.02
+    transcript_idx_max = 0
+    currect_transcript_end = 0
     ax = plt.subplot(grid[-1])
 
     transcript_plan = get_transcript_plan(ranges, transcript_file)
@@ -3300,6 +3301,12 @@ def plot_transcript(
             p[0] = 0
         if p[1] is None:
             p[1] = 0
+
+        # Reset transcript index outside of current stack
+        if p[0] > currect_transcript_end:
+            transcript_idx = 0
+
+        currect_transcript_end = max(p[1], currect_transcript_end)
 
         ax.plot(
             p, [transcript_idx, transcript_idx], "-", color="cornflowerblue", lw=0.5
@@ -3352,10 +3359,11 @@ def plot_transcript(
                 )
 
         transcript_idx += 1
+        transcript_idx_max = max(transcript_idx, transcript_idx_max)
 
     # set axis parameters
     ax.set_xlim([0, 1])
-    ax.set_ylim([transcript_idx * -0.1, 0.01+(transcript_idx * 1.01)])
+    ax.set_ylim([transcript_idx_max * -0.1, 0.01+(transcript_idx_max * 1.01)])
     ax.spines["top"].set_visible(False)
     ax.spines["bottom"].set_visible(False)
     ax.spines["left"].set_visible(False)

--- a/samplot/samplot.py
+++ b/samplot/samplot.py
@@ -3319,23 +3319,32 @@ def plot_transcript(
             color="blue",
             fontsize=annotation_fontsize,
         )
+        # Print arrows throughout gene to show direction.
+        nr_arrows = 2 + int((p[1]-p[0])/0.02)
+        arrow_locs = np.linspace(p[0], p[1], nr_arrows)
+        arrowprops = dict(arrowstyle="->", color="cornflowerblue", lw=0.5,
+                          mutation_aspect=2, mutation_scale=3)
 
         if step.info["Strand"]:
-            ax.annotate(
-                "",
-                xy=(1, transcript_idx),
-                xytext=(1 - arrow_loc, transcript_idx),
-                arrowprops=dict(arrowstyle="->", color="cornflowerblue", lw=1),
-                annotation_clip=True,
-            )
+            # Add left-facing arrows
+            for arrow_loc in arrow_locs[1:]:
+                ax.annotate(
+                    "",
+                    xy=(arrow_loc, transcript_idx),
+                    xytext=(p[0], transcript_idx),
+                    arrowprops=arrowprops,
+                    annotation_clip=True,
+                )
         else:
-            ax.annotate(
-                "",
-                xy=(1 - arrow_loc, transcript_idx),
-                xytext=(1, transcript_idx),
-                arrowprops=dict(arrowstyle="->", color="cornflowerblue", lw=1),
-                annotation_clip=True,
-            )
+            # Add right-facing arrows
+            for arrow_loc in arrow_locs[:-1]:
+                ax.annotate(
+                    "",
+                    xy=(arrow_loc, transcript_idx),
+                    xytext=(p[1], transcript_idx),
+                    arrowprops=arrowprops,
+                    annotation_clip=True,
+                )
 
         if step.info["Exons"]:
             for exon in step.info["Exons"]:

--- a/samplot/samplot.py
+++ b/samplot/samplot.py
@@ -3309,7 +3309,8 @@ def plot_transcript(
         currect_transcript_end = max(p[1], currect_transcript_end)
 
         ax.plot(
-            p, [transcript_idx, transcript_idx], "-", color="cornflowerblue", lw=0.5
+            p, [transcript_idx, transcript_idx], "-", color="cornflowerblue", lw=0.5,
+            solid_capstyle="butt",
         )
 
         # Print arrows throughout gene to show direction.
@@ -3357,6 +3358,7 @@ def plot_transcript(
                     [transcript_idx, transcript_idx],
                     "-",
                     color="cornflowerblue",
+                    solid_capstyle="butt",
                     lw=4,
                 )
 


### PR DESCRIPTION
This PR contains multiple improvement to the plotting of transcripts in `samplot`. See list below:

- Unstack transcripts that are not overlapping. This is useful when there are lots of transcript as you don't want the transcript section to take up too much space (e.g. by increasing `--annotation_scalar`). Same issue can bee seen here https://github.com/ryanlayer/samplot/issues/138.
- Move arrows showing strand direction into transcripts, these are currently stuck to the right side of the image. 
-  Place multiple arrow throughout transcript, this way they should not be covered by exons. 
- Use `solid_capstyle="butt"` for transcript and exons since default projects the drawings outside the defined start/end positions. 


**Before**
![image](https://user-images.githubusercontent.com/27061883/163417419-4ad3d133-83f6-4cec-a8f4-6af0f9024534.png)


**After**
![test](https://user-images.githubusercontent.com/27061883/163415855-fb8bec8e-4f23-4d98-8836-4a3850c68bd2.png)

Images generated using command below:
```
samplot plot -c 2 -s 59405943 -e 59405943 -c X -s 151118533 -e 151118533 -b test/data/2_59305747-59505747_X_151018513-151218513.BND.bam -o test.png -t BND -T test/data/Homo_sapiens.GRCh37.82.sort.2_X.gff3.gz --zoom 30000 --jitter --annotation_scalar 5 -a --annotation_fontsize 3
```