### PR TITLE
Show a popup error when an image is missing

### DIFF
--- a/samplot/templates/samplot_vcf.html
+++ b/samplot/templates/samplot_vcf.html
@@ -244,6 +244,9 @@
         if ( row.chrom2) {
             img.src = `${row.svtype}_${row.chrom}_${row.start}_${row.chrom2}_${row.end}.${plot_type}`
         }
+        img.onerror = function(){
+           alert(`${img.src} not found`);
+        }
         let viewer = new Viewer(img, {
             hidden: function () {
                 viewer.destroy()


### PR DESCRIPTION
If an image is missing, there is currently just an infinite spinning wheel. This PR adds a helpful popup with info about which file that is missing. Example below

<img width="1268" alt="image" src="https://user-images.githubusercontent.com/27061883/201152733-bb0762f8-2621-4014-89a3-feafb89943a8.png">
