### PR TITLE
Improve logging and exit samplot vcf if not samples match

### DIFF
--- a/samplot/__main__.py
+++ b/samplot/__main__.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 import argparse
+import logging
 import sys
 
 from .__init__ import __version__
@@ -8,6 +9,9 @@ from .samplot_vcf import add_vcf
 
 
 def main(args=None):
+    logging.basicConfig(level=logging.INFO, stream=sys.stderr,
+                        format="%(module)s - %(levelname)s: %(message)s")
+    
     if args is None:
         args = sys.argv[1:]
 

--- a/samplot/samplot_vcf.py
+++ b/samplot/samplot_vcf.py
@@ -1113,6 +1113,14 @@ def vcf(parser, args, pass_through_args):
     # connect the sample IDs to bam files
     names_to_bams = get_names_to_bams(args.bams, args.sample_ids)
 
+    # check that at least one sample is can be plotted  
+    if not any(vcf_sample in names_to_bams for vcf_sample in vcf_samples):
+        other = "'--sample_ids'" if args.sample_ids else "BAM"
+        logger.error("Samples in VCF do not match samples specified in {}".format(other))
+        logger.error("VCF samples: {}".format(', '.join(vcf_samples)))
+        logger.error("{} samples: {}".format(other, ', '.join(vcf_samples)))
+        sys.exit(1)
+
     # if important regions are included, load those intervals
     # and only show SVs inside them
     important_regions = read_important_regions(args.important_regions)

--- a/samplot/samplot_vcf.py
+++ b/samplot/samplot_vcf.py
@@ -1051,7 +1051,7 @@ def generate_commands(
         )
         commands.append(command)
 
-    logger.debug("VCF entry count:", var_count + 1)
+    logger.debug("VCF entry count: {}".format(var_count + 1))
     return commands, table_data
 
 


### PR DESCRIPTION
This PR add a logger to handle messages of different kinds. Debug handling is greatly simplified by this. 

I aslo added a check for if no samples in the VCF match those in the BAM or specified with `--sample_ids` when running `samplot vcf`. Before it was quite hard to tell why nothing was outputted as you would only get a message stating `no plottable samples with matched alignment files` for each SVs, se e.g https://github.com/ryanlayer/samplot/issues/176.
