### PR TITLE
samplot vcf - Add stats about filtered variants

### DIFF
--- a/samplot/__main__.py
+++ b/samplot/__main__.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 import argparse
+import logging
 import sys
 
 from .__init__ import __version__
@@ -8,6 +9,9 @@ from .samplot_vcf import add_vcf
 
 
 def main(args=None):
+    logging.basicConfig(level=logging.INFO, stream=sys.stderr,
+                        format="%(module)s - %(levelname)s: %(message)s")
+    
     if args is None:
         args = sys.argv[1:]
 

--- a/samplot/samplot_vcf.py
+++ b/samplot/samplot_vcf.py
@@ -1113,6 +1113,14 @@ def vcf(parser, args, pass_through_args):
     # connect the sample IDs to bam files
     names_to_bams = get_names_to_bams(args.bams, args.sample_ids)
 
+    # check that at least one sample is can be plotted  
+    if not any(vcf_sample in names_to_bams for vcf_sample in vcf_samples):
+        other = "'--sample_ids'" if args.sample_ids else "BAM"
+        logger.error("Samples in VCF do not match samples specified in {}".format(other))
+        logger.error("VCF samples: {}".format(', '.join(vcf_samples)))
+        logger.error("{} samples: {}".format(other, ', '.join(vcf_samples)))
+        sys.exit(1)
+
     # if important regions are included, load those intervals
     # and only show SVs inside them
     important_regions = read_important_regions(args.important_regions)

--- a/samplot/samplot_vcf.py
+++ b/samplot/samplot_vcf.py
@@ -1051,7 +1051,7 @@ def generate_commands(
         )
         commands.append(command)
 
-    logger.debug("VCF entry count:", var_count + 1)
+    logger.debug("VCF entry count: {}".format(var_count + 1))
     return commands, table_data
 
 


### PR DESCRIPTION
Add stats about how many variants are filtered out when using `samplot vcf`. 

Relates to https://github.com/ryanlayer/samplot/issues/140

Example:
```
$ samplot vcf -d tmp --vcf test/data/test.vcf --sample_ids HG002 HG003 HG004 -b test/data/HG002_Illumina.bam test/data/HG003_Illumina.bam test/data/HG004_Illumina.bam --debug
samplot_vcf - DEBUG: Skipping DEL at 1:43059289-43059950, no samples have non-ref genotypes
samplot_vcf - DEBUG: VCF entry count: 9
samplot_vcf - DEBUG: VCF entrys filtered out: 1
samplot_vcf - DEBUG:  - Filtered out: 1
samplot - WARNING: Window size is under 1.5x the estimated fragment length and will be resized to 847. Rerun with -w 604 to override
```

This PR should be merged after https://github.com/ryanlayer/samplot/pull/177