### PR TITLE
Fix legend for long reads

### DIFF
--- a/samplot/samplot.py
+++ b/samplot/samplot.py
@@ -468,8 +468,6 @@ def add_pair_end(bam_file, read, pairs, linked_reads, ignore_hp):
     if not ignore_hp and read.has_tag("HP"):
         HP_tag = int(read.get_tag("HP"))
 
-    READ_TYPES_USED["Paired-end read"] = True
-
     pe = PairedEnd(
         bam_file.get_reference_name(read.reference_id),
         read.reference_start,
@@ -486,7 +484,6 @@ def add_pair_end(bam_file, read, pairs, linked_reads, ignore_hp):
         pairs[pe.HP][read.query_name] = []
 
     if pe.MI:
-        READ_TYPES_USED["Linked read"] = True
         if pe.HP not in linked_reads:
             linked_reads[pe.HP] = {}
 
@@ -723,6 +720,8 @@ def plot_pair_plan(ranges, step, ax, marker_size, jitter_bounds):
     if not points_in_window(p):
         return False
 
+    READ_TYPES_USED["Paired-end read"] = True
+
     y = step.info["INSERTSIZE"]
 
     # Offset y-values using jitter to avoid overlapping lines
@@ -875,7 +874,6 @@ def add_split(read, splits, bam_file, linked_reads, ignore_hp):
     if not read.has_tag("SA"):
         return
 
-    READ_TYPES_USED["Split-read"] = True
     qs_pos, qe_pos = calc_query_pos_from_cigar(read.cigarstring, (not read.is_reverse))
 
     HP_tag = False
@@ -1040,6 +1038,8 @@ def plot_split_plan(ranges, step, ax, marker_size, jitter_bounds):
     # some points are far outside of the printable area, so we ignore them
     if not points_in_window(p):
         return False
+
+    READ_TYPES_USED["Split-read"] = True
 
     y = step.info["INSERTSIZE"]
 
@@ -1244,8 +1244,6 @@ def add_long_reads(bam_file, read, long_reads, min_event_size, ignore_hp):
     Alignments belonging to the LongRead instance combined if within the
     min_event_size distance apart
     """
-    READ_TYPES_USED["Aligned long read"] = True
-
     if read.is_supplementary or read.is_secondary:
         return
 
@@ -1776,6 +1774,8 @@ def plot_linked_reads(
             if not points_in_window(p):
                 continue
 
+            READ_TYPES_USED["Linked read"] = True
+
             ax.plot(
                 p, [insert_size, insert_size], "-", color="green", alpha=0.75, lw=0.25
             )
@@ -1832,12 +1832,17 @@ def plot_long_reads(long_reads, ax, ranges, curr_min_insert_size, curr_max_inser
             if not points_in_window(p):
                 continue
 
-            if step.info["TYPE"] == "Align":
+            READ_TYPES_USED["Aligned long read"] = True
+
+            event_type = step.info["TYPE"]
+            READ_TYPES_USED[event_type] = True
+
+            if event_type == "Align":
                 ax.plot(
                     p,
                     [max_gap, max_gap],
                     "-",
-                    color=colors[step.info["TYPE"]],
+                    color=colors[event_type],
                     alpha=0.25,
                     lw=1,
                 )
@@ -1859,7 +1864,7 @@ def plot_long_reads(long_reads, ax, ranges, curr_min_insert_size, curr_max_inser
                         [Path.MOVETO, Path.CURVE4, Path.CURVE4, Path.CURVE4],
                     ),
                     fc="none",
-                    color=colors[step.info["TYPE"]],
+                    color=colors[event_type],
                     alpha=0.25,
                     lw=1,
                     ls=":",
@@ -2946,11 +2951,7 @@ def plot_legend(fig, legend_fontsize, marker_size):
             )
         ]
 
-    if (
-        READ_TYPES_USED["Paired-end read"]
-        or READ_TYPES_USED["Deletion/Normal"]
-        or READ_TYPES_USED["Inversion"]
-    ):
+    if READ_TYPES_USED["Paired-end read"]:
         marker_labels.append("Paired-end read")
         legend_elements += [
             plt.Line2D(


### PR DESCRIPTION
fix #171, #130

Now only read types that are actually plotted in appear in the legend. 

Example from (#171)

```
samplot plot -b output.bam -c 1 -s 39477269 -e 39530389 -t INV -o output.png
```
![output](https://github.com/ryanlayer/samplot/assets/27061883/3a651d65-823a-449a-b17c-f2332855dbee)
