### PR TITLE
Jitter long reads

### DIFF
--- a/samplot/samplot.py
+++ b/samplot/samplot.py
@@ -1794,7 +1794,7 @@ def plot_linked_reads(
 # }}}
 
 # {{{def plot_long_reads(long_reads,
-def plot_long_reads(long_reads, ax, ranges, curr_min_insert_size, curr_max_insert_size):
+def plot_long_reads(long_reads, ax, ranges, curr_min_insert_size, curr_max_insert_size, jitter_bounds):
     """Plots all LongReads for the region
     """
 
@@ -1852,8 +1852,8 @@ def plot_long_reads(long_reads, ax, ranges, curr_min_insert_size, curr_max_inser
                     Path(
                         [
                             (x1, max_gap),
-                            (x1, max_gap * 1.1),
-                            (x2, max_gap * 1.1),
+                            (x1, jitter(max_gap * 1.1, bounds=jitter_bounds)),
+                            (x2, jitter(max_gap * 1.1, bounds=jitter_bounds)),
                             (x2, max_gap),
                         ],
                         [Path.MOVETO, Path.CURVE4, Path.CURVE4, Path.CURVE4],
@@ -2782,6 +2782,7 @@ def plot_samples(
                     ranges,
                     curr_min_insert_size,
                     curr_max_insert_size,
+                    jitter_bounds
                 )
             else:
                 curr_min_insert_size, curr_max_insert_size = plot_pairs(

--- a/samplot/samplot.py
+++ b/samplot/samplot.py
@@ -1846,13 +1846,14 @@ def plot_long_reads(long_reads, ax, ranges, curr_min_insert_size, curr_max_inser
             else:
                 x1 = p[0]
                 x2 = p[1]
-
+                # get offset to bend the line up
+                max_gap_offset = max(jitter(max_gap * 1.1, bounds=jitter_bounds), max_gap)
                 pp = mpatches.PathPatch(
                     Path(
                         [
                             (x1, max_gap),
-                            (x1, jitter(max_gap * 1.1, bounds=jitter_bounds)),
-                            (x2, jitter(max_gap * 1.1, bounds=jitter_bounds)),
+                            (x1, max_gap_offset),
+                            (x2, max_gap_offset),
                             (x2, max_gap),
                         ],
                         [Path.MOVETO, Path.CURVE4, Path.CURVE4, Path.CURVE4],
@@ -1866,7 +1867,7 @@ def plot_long_reads(long_reads, ax, ranges, curr_min_insert_size, curr_max_inser
                 ax.add_patch(pp)
 
                 # add some room for the bend line
-                curr_max_insert_size = max(curr_max_insert_size, max_gap * 1.1)
+                curr_max_insert_size = max(curr_max_insert_size, max_gap_offset)
 
     return [curr_min_insert_size, curr_max_insert_size]
 

--- a/samplot/samplot.py
+++ b/samplot/samplot.py
@@ -1842,8 +1842,7 @@ def plot_long_reads(long_reads, ax, ranges, curr_min_insert_size, curr_max_inser
                     lw=1,
                 )
 
-                if curr_max_insert_size and (max_gap > curr_max_insert_size):
-                    curr_max_insert_size = max_gap
+                curr_max_insert_size = max(curr_max_insert_size, max_gap)
             else:
                 x1 = p[0]
                 x2 = p[1]
@@ -1867,10 +1866,7 @@ def plot_long_reads(long_reads, ax, ranges, curr_min_insert_size, curr_max_inser
                 ax.add_patch(pp)
 
                 # add some room for the bend line
-                if (
-                    curr_max_insert_size is None
-                ) or max_gap * 1.1 > curr_max_insert_size:
-                    curr_max_insert_size = max_gap * 1.1
+                curr_max_insert_size = max(curr_max_insert_size, max_gap * 1.1)
 
     return [curr_min_insert_size, curr_max_insert_size]
 


### PR DESCRIPTION
This PR enables the `--jitter` argument when using long reads. The `--jitter` argument added in https://github.com/ryanlayer/samplot/pull/147 so far has only applied to short reads. This could however be useful for long reads, see e.g. images in #171. Many of the curves overlap so it is hard to assay SV support. 

## Example
### No jitter
```
samplot plot -b output.bam -c 1 -s 39477269 -e 39530389 -t INV -o output.png
```
![output](https://github.com/ryanlayer/samplot/assets/27061883/cc94b65d-c7f0-42f2-8ed9-76696bce94aa)

### Jitter
```
samplot plot -b output.bam -c 1 -s 39477269 -e 39530389 -t INV -o output.png --jitter
```
![output](https://github.com/ryanlayer/samplot/assets/27061883/95eed842-13ea-448f-aed0-0c2ac323c974)
