### PR TITLE
Fix failing tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![CircleCI](https://circleci.com/gh/jbelyeu/samplot/tree/master.svg?style=svg)](https://circleci.com/gh/jbelyeu/samplot/tree/master)
+[![CircleCI](https://circleci.com/gh/ryanlayer/samplot/tree/master.svg?style=svg)](https://circleci.com/gh/ryanlayer/samplot/tree/master)
 [![install with bioconda](https://img.shields.io/badge/install%20with-bioconda-brightgreen.svg?style=flat)](http://bioconda.github.io/recipes/samplot/README.html)
 
 <center><img src="/doc/imgs/samplot_logo_v5.png" width="300"/></center>

--- a/samplot/samplot.py
+++ b/samplot/samplot.py
@@ -2576,7 +2576,7 @@ def get_read_data(
             # for high quality reads and the second column low quality reads. Otherwise
             # all coverage will be in the second column.
             range_len = range_end - range_start
-            range_hp_coverage = {hp: np.zeros((range_len, 2), dtype=np.int) for hp in haplotypes}
+            range_hp_coverage = {hp: np.zeros((range_len, 2), dtype=int) for hp in haplotypes}
 
             for read in bam_iter:
                 if (


### PR DESCRIPTION
I was running tests locally with numpy 1.22.0 without issues but CI is run with numpy 1.24.3 (latest). Calling `np.int` was apparently [depreciated in numpy 1.24.0](https://numpy.org/devdocs/release/1.24.0-notes.html#expired-deprecations).

Also update the CI flag to point to this repo. 