### PR TITLE
Temporary fix #189 by limiting matplotlib to <3.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-matplotlib
+matplotlib<3.7
 numpy
 pysam>=0.15
 wget


### PR DESCRIPTION
fix #189 