### PR TITLE
fixes for python 3.11

### DIFF
--- a/samplot/samplot.py
+++ b/samplot/samplot.py
@@ -520,7 +520,7 @@ def sample_normal(max_depth, pairs, z):
                 inside_norm[read_name] = pair
 
         if len(inside_norm) > max_depth:
-            for read_name in random.sample(inside_norm.keys(), max_depth):
+            for read_name in random.sample(sorted(inside_norm.keys()), max_depth):
                 sampled_pairs[read_name] = inside_norm[read_name]
         else:
             for read_name in inside_norm:

--- a/samplot/samplot.py
+++ b/samplot/samplot.py
@@ -520,7 +520,7 @@ def sample_normal(max_depth, pairs, z):
                 inside_norm[read_name] = pair
 
         if len(inside_norm) > max_depth:
-            for read_name in random.sample(sorted(inside_norm.keys()), max_depth):
+            for read_name in random.sample(list(inside_norm.keys()), max_depth):
                 sampled_pairs[read_name] = inside_norm[read_name]
         else:
             for read_name in inside_norm:


### PR DESCRIPTION
Hello, and thanks for samplot!

random.sample() must be given a sequence, which for dict keys means that one must `sorted()` them. This was heralded by a deprecation warning in earlier python versions. I think this is the only occurrence, and samplot now runs correctly AFAICT, but there may be other python3.11 issues I haven't found yet.

Thanks,
K