### PR TITLE
Don't crash on an empty vcf

### DIFF
--- a/samplot/samplot_vcf.py
+++ b/samplot/samplot_vcf.py
@@ -958,7 +958,8 @@ def generate_commands(
             logger.warning(
                 "BAMs missing from VCF samples: {}".format(", ".join(missing_bam_samples))
             )
-
+    
+    var_count = 0 # define it here, in case of zero variants (otherwise it will raise NameError when used below)
     for var_count, variant in enumerate(vcf):
         translocation_chrom = None
         svtype = variant.info.get("SVTYPE", "SV")


### PR DESCRIPTION
Hi folks,

In `samplot vcf`, the accumulator variable for the number of parsed variants uses `enumerate()`, which means that the `var_count` variable wasn't define if there were no variants in the file. Likely, an empty vcf should be an error that is reported somewhere, but for now I at least define the variable so as not to get a rather inscrutable `NameError`.


Thanks
K